### PR TITLE
Update __init__.py lines 77-78 for Python 3 compatibility

### DIFF
--- a/sphinx_execute_code/__init__.py
+++ b/sphinx_execute_code/__init__.py
@@ -74,8 +74,15 @@ class ExecuteCode(Directive):
             'foobar'
         """
 
-        output = StringIO.StringIO()
-        err = StringIO.StringIO()
+        # Added by @stephanobryan for python 3
+        if sys.version_info.major == 2:
+            from StringIO import StringIO
+            output = StringIO.StringIO()
+            err = StringIO.StringIO()
+        else:
+            import io
+            output = io.StringIO()
+            err = io.StringIO()
 
         sys.stdout = output
         sys.stderr = err


### PR DESCRIPTION
Hi @jpsenior ,
Thanks for the great package :-). Though I have a little input: 
I'd substitut lines 77-78 in the old _init_.py with lines 77-85, so that it is Python 3 compatible. 
Cheers..